### PR TITLE
Apply hints suggested by the multi-arch hinter

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+hunspell-kk (1.1-3) UNRELEASED; urgency=low
+
+  * Apply multi-arch hints.
+    + hunspell-kk: Add Multi-Arch: foreign.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Mon, 14 Sep 2020 11:21:56 -0000
+
 hunspell-kk (1.1-2) unstable; urgency=low
 
   * debian/control:

--- a/debian/control
+++ b/debian/control
@@ -15,6 +15,7 @@ Depends: dictionaries-common (>= 1.12.11), ${misc:Depends}
 Provides: hunspell-dictionary, hunspell-dictionary-kk, myspell-dictionary, myspell-dictionary-kk
 Suggests: iceape-browser | iceweasel | icedove, openoffice.org (>= 1.0.3-3)
 Conflicts: openoffice.org (<= 1.0.3-2)
+Multi-Arch: foreign
 Description: Kazakh dictionary for hunspell
  This dictionary contains Kazakh wordlist for the hunspell
  spellchecker currently supported by Mozilla and LibreOffice.


### PR DESCRIPTION
Apply hints suggested by the multi-arch hinter.

* hunspell-kk: Add Multi-Arch: foreign. This fixes: hunspell-kk could be marked Multi-Arch: foreign. ([ma-foreign](https://wiki.debian.org/MultiArch/Hints#ma-foreign))

These changes were suggested on https://wiki.debian.org/MultiArch/Hints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/multiarch-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/multiarch-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/multiarch-fixes/pkg/hunspell-kk/b890b476-4790-431a-88f5-032ab62ef583.


## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* {+Multi-Arch: foreign+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/b890b476-4790-431a-88f5-032ab62ef583/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/b890b476-4790-431a-88f5-032ab62ef583/diffoscope)).
