### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+hunspell-kk (1.1-3) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since buster:
+    + Build-Depends: Drop versioned constraint on debhelper.
+    + Build-Depends-Indep: Drop versioned constraint on dictionaries-common-dev.
+    + hunspell-kk: Drop versioned constraint on dictionaries-common in Depends.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Thu, 09 Sep 2021 19:28:10 -0000
+
 hunspell-kk (1.1-2) unstable; urgency=low
 
   * debian/control:

--- a/debian/control
+++ b/debian/control
@@ -2,8 +2,8 @@ Source: hunspell-kk
 Section: text
 Priority: optional
 Maintainer: Timur Birsh <taem@linukz.org>
-Build-Depends: debhelper (>= 9)
-Build-Depends-Indep: dictionaries-common-dev (>= 1.12.11)
+Build-Depends: debhelper
+Build-Depends-Indep: dictionaries-common-dev
 Standards-Version: 3.9.4
 Homepage: http://extensions.services.openoffice.org/en/project/dict-kk
 Vcs-Git: git://github.com/taem/hunspell-kk.git
@@ -11,7 +11,7 @@ Vcs-Browser: http://github.com/taem/hunspell-kk/tree/master
 
 Package: hunspell-kk
 Architecture: all
-Depends: dictionaries-common (>= 1.12.11), ${misc:Depends}
+Depends: dictionaries-common, ${misc:Depends}
 Provides: hunspell-dictionary, hunspell-dictionary-kk, myspell-dictionary, myspell-dictionary-kk
 Suggests: iceape-browser | iceweasel | icedove, openoffice.org (>= 1.0.3-3)
 Conflicts: openoffice.org (<= 1.0.3-2)


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/hunspell-kk/d5d609f7-e37d-4acf-98ec-61e4b2c38b86.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* Depends: dictionaries-common [-(>= 1.12.11)-]


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/d5d609f7-e37d-4acf-98ec-61e4b2c38b86/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/d5d609f7-e37d-4acf-98ec-61e4b2c38b86/diffoscope)).
