### PR TITLE
Apply multi-arch hints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,6 +15,7 @@ Depends: dictionaries-common (>= 1.12.11), ${misc:Depends}
 Provides: hunspell-dictionary, hunspell-dictionary-kk, myspell-dictionary, myspell-dictionary-kk
 Suggests: iceape-browser | iceweasel | icedove, openoffice.org (>= 1.0.3-3)
 Conflicts: openoffice.org (<= 1.0.3-2)
+Multi-Arch: foreign
 Description: Kazakh dictionary for hunspell
  This dictionary contains Kazakh wordlist for the hunspell
  spellchecker currently supported by Mozilla and LibreOffice.


### PR DESCRIPTION
Apply hints suggested by the [multi-arch hinter](https://wiki.debian.org/MultiArch/Hints).

* hunspell-kk: Add Multi-Arch: foreign. This fixes: hunspell-kk could be marked Multi-Arch: foreign. ([ma-foreign](https://wiki.debian.org/MultiArch/Hints#ma-foreign))

Note that in some cases, these multi-arch hints may trigger lintian warnings until the dependencies of the package support multi-arch. This is expected, see [https://janitor.debian.net/multiarch-fixes#why-does-lintian-warn](the FAQ) for details.

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/multiarch-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/multiarch-fixes/pkg/hunspell-kk/0bcddd1f-f0db-47b9-bced-e3cc9bbc0466.