### PR TITLE
Move orphaned package to the QA team

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+hunspell-kk (1.1-3) UNRELEASED; urgency=low
+
+  * QA Upload.
+    Orphan package - see bug 879871.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Thu, 29 Sep 2022 15:55:10 -0000
+
 hunspell-kk (1.1-2) unstable; urgency=low
 
   * debian/control:

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: hunspell-kk
 Section: text
 Priority: optional
-Maintainer: Timur Birsh <taem@linukz.org>
+Maintainer: Debian QA Group <packages@qa.debian.org>
 Build-Depends: debhelper (>= 9)
 Build-Depends-Indep: dictionaries-common-dev (>= 1.12.11)
 Standards-Version: 3.9.4


### PR DESCRIPTION

Move orphaned package to the QA team.


For details, see the [orphan bug](https://bugs.debian.org/879871).





This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/orphan).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/orphan.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/orphan/pkg/hunspell-kk/4f261f56-672e-4f5e-9de7-95a735cf062d.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* Maintainer: [-Timur Birsh <taem@linukz.org>-] {+Debian QA Group <packages@qa.debian.org>+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/4f261f56-672e-4f5e-9de7-95a735cf062d/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/4f261f56-672e-4f5e-9de7-95a735cf062d/diffoscope)).
